### PR TITLE
rename event methods to prevent conflicts with other activejob libraries

### DIFF
--- a/activejob-scheduler.gemspec
+++ b/activejob-scheduler.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_development_dependency 'bundler', '>= 1', '< 3'
   spec.add_development_dependency 'mocha', '~> 1.9'

--- a/lib/active_job/scheduler/engine.rb
+++ b/lib/active_job/scheduler/engine.rb
@@ -9,8 +9,8 @@ module ActiveJob
       config.eager_load_namespaces << ActiveJob::Scheduler
 
       initializer 'active_job.scheduler' do
-        ActiveJob::Base.send :include, ActiveJob::Scheduler::Job
-        ActionMailer::Base.send :include, ActiveJob::Scheduler::Mailer
+        ActiveJob::Base.include ActiveJob::Scheduler::Job
+        ActionMailer::Base.include ActiveJob::Scheduler::Mailer
       end
     end
   end

--- a/lib/active_job/scheduler/job.rb
+++ b/lib/active_job/scheduler/job.rb
@@ -13,14 +13,14 @@ module ActiveJob
 
       included do
         after_perform :enqueue_job, if: :scheduled?
-        class_attribute :to_event
+        class_attribute :to_scheduler_event
       end
 
       class_methods do
         # Default name for the scheduled event.
         #
         # @return [String] class name without "Job" at the end
-        def event_name
+        def scheduler_event_name
           name.gsub(/Job\Z/, '')
         end
 
@@ -46,13 +46,13 @@ module ActiveJob
         #   end
         def repeat(
           nat = nil,
-          name: event_name,
+          name: scheduler_event_name,
           arguments: [],
           each: nil,
           **interval
         )
           interval = { nat: nat } if nat.present?
-          self.to_event = {
+          self.to_scheduler_event = {
             name: name,
             arguments: arguments,
             interval: interval,
@@ -67,7 +67,7 @@ module ActiveJob
       #
       # @private
       def enqueue_job
-        event.enqueue(*arguments)
+        scheduler_event.enqueue(*arguments)
       end
 
       # Whether this job is scheduled.
@@ -75,15 +75,15 @@ module ActiveJob
       # @private
       # @return [Boolean]
       def scheduled?
-        event.present?
+        scheduler_event.present?
       end
 
       # Event from the schedule
       #
       # @private
       # @return [ActiveJob::Scheduler::Event]
-      def event
-        @event ||= Scheduler.events.find_by_name(self.class.name)
+      def scheduler_event
+        @scheduler_event ||= Scheduler.events.find_by_name(self.class.name)
       end
     end
   end

--- a/lib/active_job/scheduler/mailer.rb
+++ b/lib/active_job/scheduler/mailer.rb
@@ -7,7 +7,7 @@ module ActiveJob
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :events
+        class_attribute :scheduler_events
       end
 
       class_methods do
@@ -18,8 +18,8 @@ module ActiveJob
         # @param [Array] arguments - Args to pass to the mailer method
         def repeat(mail, nat = nil, arguments: [], each: nil, **interval)
           interval = { nat: nat } if nat.present?
-          self.events ||= []
-          self.events << {
+          self.scheduler_events ||= []
+          self.scheduler_events << {
             name: "#{name}##{mail}",
             class_name: name,
             arguments: arguments,

--- a/test/active_job/scheduler/mailer_test.rb
+++ b/test/active_job/scheduler/mailer_test.rb
@@ -6,9 +6,9 @@ module ActiveJob
   module Scheduler
     class MailerTest < ActiveSupport::TestCase
       test 'add events' do
-        refute_empty UserMailer.events
-        assert_equal 'UserMailer#daily_status', UserMailer.events.first[:name]
-        refute_equal MultiMailer.events, UserMailer.events
+        refute_empty UserMailer.scheduler_events
+        assert_equal 'UserMailer#daily_status', UserMailer.scheduler_events.first[:name]
+        refute_equal MultiMailer.scheduler_events, UserMailer.scheduler_events
       end
     end
   end

--- a/test/active_job/scheduler/schedule_test.rb
+++ b/test/active_job/scheduler/schedule_test.rb
@@ -21,7 +21,7 @@ module ActiveJob
           }
         )
 
-        assert_equal 'FooBarJob', @schedule.send(:events).first.job_class_name
+        assert_equal 'FooBarJob', @schedule.send(:scheduler_events).first.job_class_name
         refute_nil @schedule.find_by_name('FooBarJob')
       end
 
@@ -36,9 +36,9 @@ module ActiveJob
             'every' => '1h'
           }
         )
-        @schedule.expects(:events_from_jobs).returns([])
+        @schedule.expects(:scheduler_events_from_jobs).returns([])
 
-        refute_empty @schedule.send(:events)
+        refute_empty @schedule.send(:scheduler_events)
         refute_empty @schedule.start
       end
 

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActionDispatch::IntegrationTest.fixture_path =
     ActiveSupport::TestCase.fixture_path
   ActiveSupport::TestCase.file_fixture_path =
-    ActiveSupport::TestCase.fixture_path + '/files'
+    "#{ActiveSupport::TestCase.fixture_path}/files"
 
   ActiveSupport::TestCase.fixtures :all
 end


### PR DESCRIPTION
also ran the Rubocop auto update and fixed the remaining rubocop issues